### PR TITLE
refactor(backend): Actor pattern, cleanup, DRY extraction

### DIFF
--- a/apps/backend/bun.lock
+++ b/apps/backend/bun.lock
@@ -8,7 +8,6 @@
         "@elysiajs/bearer": "^1.4.3",
         "@elysiajs/cors": "^1.4.1",
         "@elysiajs/openapi": "^1.4.14",
-        "@elysiajs/swagger": "^1.3.1",
         "@t3-oss/env-core": "^0.13.10",
         "drizzle-orm": "^0.45.1",
         "drizzle-typebox": "^0.3.3",
@@ -55,8 +54,6 @@
     "@elysiajs/cors": ["@elysiajs/cors@1.4.1", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-lQfad+F3r4mNwsxRKbXyJB8Jg43oAOXjRwn7sKUL6bcOW3KjUqUimTS+woNpO97efpzjtDE0tEjGk9DTw8lqTQ=="],
 
     "@elysiajs/openapi": ["@elysiajs/openapi@1.4.14", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-kWmJWdvP8/LwHwAJXSpz6xFfYUoyUyEPRimEYABuDU1rOnS27Da1u9T2jyU7frOopxKWV/wDfDxMP8z2xdCPJw=="],
-
-    "@elysiajs/swagger": ["@elysiajs/swagger@1.3.1", "", { "dependencies": { "@scalar/themes": "^0.9.52", "@scalar/types": "^0.0.12", "openapi-types": "^12.1.3", "pathe": "^1.1.2" }, "peerDependencies": { "elysia": ">= 1.3.0" } }, "sha512-LcbLHa0zE6FJKWPWKsIC/f+62wbDv3aXydqcNPVPyqNcaUgwvCajIi+5kHEU6GO3oXUCpzKaMsb3gsjt8sLzFQ=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
@@ -114,12 +111,6 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
-    "@scalar/openapi-types": ["@scalar/openapi-types@0.1.1", "", {}, "sha512-NMy3QNk6ytcCoPUGJH0t4NNr36OWXgZhA3ormr3TvhX1NDgoF95wFyodGVH8xiHeUyn2/FxtETm8UBLbB5xEmg=="],
-
-    "@scalar/themes": ["@scalar/themes@0.9.86", "", { "dependencies": { "@scalar/types": "0.1.7" } }, "sha512-QUHo9g5oSWi+0Lm1vJY9TaMZRau8LHg+vte7q5BVTBnu6NuQfigCaN+ouQ73FqIVd96TwMO6Db+dilK1B+9row=="],
-
-    "@scalar/types": ["@scalar/types@0.0.12", "", { "dependencies": { "@scalar/openapi-types": "0.1.1", "@unhead/schema": "^1.9.5" } }, "sha512-XYZ36lSEx87i4gDqopQlGCOkdIITHHEvgkuJFrXFATQs9zHARop0PN0g4RZYWj+ZpCUclOcaOjbCt8JGe22mnQ=="],
-
     "@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
 
     "@t3-oss/env-core": ["@t3-oss/env-core@0.13.10", "", { "peerDependencies": { "arktype": "^2.1.0", "typescript": ">=5.0.0", "valibot": "^1.0.0-beta.7 || ^1.0.0", "zod": "^3.24.0 || ^4.0.0" }, "optionalPeers": ["arktype", "typescript", "valibot", "zod"] }, "sha512-NNFfdlJ+HmPHkLi2HKy7nwuat9SIYOxei9K10lO2YlcSObDILY7mHZNSHsieIM3A0/5OOzw/P/b+yLvPdaG52g=="],
@@ -131,8 +122,6 @@
     "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 
     "@types/node": ["@types/node@25.1.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA=="],
-
-    "@unhead/schema": ["@unhead/schema@1.11.20", "", { "dependencies": { "hookable": "^5.5.3", "zhead": "^2.2.4" } }, "sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -164,8 +153,6 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w=="],
 
-    "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
-
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
@@ -174,11 +161,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
-
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
-
-    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
     "postgres": ["postgres@3.4.8", "", {}, "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg=="],
 
@@ -194,21 +177,15 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
-    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
-
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
-    "zhead": ["zhead@2.2.4", "", {}, "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag=="],
-
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
-
-    "@scalar/themes/@scalar/types": ["@scalar/types@0.1.7", "", { "dependencies": { "@scalar/openapi-types": "0.2.0", "@unhead/schema": "^1.11.11", "nanoid": "^5.1.5", "type-fest": "^4.20.0", "zod": "^3.23.8" } }, "sha512-irIDYzTQG2KLvFbuTI8k2Pz/R4JR+zUUSykVTbEMatkzMmVFnn1VzNSMlODbadycwZunbnL2tA27AXed9URVjw=="],
 
     "tsx/esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
@@ -255,10 +232,6 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
-
-    "@scalar/themes/@scalar/types/@scalar/openapi-types": ["@scalar/openapi-types@0.2.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-waiKk12cRCqyUCWTOX0K1WEVX46+hVUK+zRPzAahDJ7G0TApvbNkuy5wx7aoUyEk++HHde0XuQnshXnt8jsddA=="],
-
-    "@scalar/themes/@scalar/types/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -25,7 +25,7 @@
     "@elysiajs/bearer": "^1.4.3",
     "@elysiajs/cors": "^1.4.1",
     "@elysiajs/openapi": "^1.4.14",
-    "@elysiajs/swagger": "^1.3.1",
+
     "@t3-oss/env-core": "^0.13.10",
     "drizzle-orm": "^0.45.1",
     "drizzle-typebox": "^0.3.3",

--- a/apps/backend/src/common/utils.ts
+++ b/apps/backend/src/common/utils.ts
@@ -1,3 +1,4 @@
+import type { Actor } from "@/plugins/auth";
 import { ForbiddenError, NotFoundError } from "@/plugins/error";
 
 export function assertExists<T>(
@@ -20,14 +21,12 @@ export function escapeLike(str: string): string {
   return str.replace(/[%_\\]/g, "\\$&");
 }
 
-/** Reusable ownership + admin check */
-export function assertOwnerOrAdmin(
+/** Owner or admin bypass — works with the 3-role hierarchy */
+export function assertAccess(
   resourceUserId: string,
-  currentUserId: string,
-  isAdmin: boolean,
+  actor: Actor,
   message = "You do not have access to this resource",
 ): void {
-  if (resourceUserId !== currentUserId && !isAdmin) {
-    throw new ForbiddenError(message);
-  }
+  if (resourceUserId === actor.sub || actor.is("admin")) return;
+  throw new ForbiddenError(message);
 }

--- a/apps/backend/src/modules/auth/index.ts
+++ b/apps/backend/src/modules/auth/index.ts
@@ -97,22 +97,16 @@ export const auth = new Elysia({ prefix: "/auth", detail: { tags: ["Auth"] } })
     },
   )
 
-  .post(
-    "/logout",
-    async ({ body }) => {
-      return AuthService.logout(body.refreshToken);
+  .post("/logout", ({ body }) => AuthService.logout(body.refreshToken), {
+    body: AuthModel.LogoutBody,
+    response: {
+      200: t.Object({ message: t.String() }),
     },
-    {
-      body: AuthModel.LogoutBody,
-      response: {
-        200: t.Object({ message: t.String() }),
-      },
-      detail: {
-        summary: "Logout",
-        description: "Logout user and revoke refresh token",
-      },
+    detail: {
+      summary: "Logout",
+      description: "Logout user and revoke refresh token",
     },
-  )
+  })
 
   .get(
     "/me",

--- a/apps/backend/src/modules/exams/index.ts
+++ b/apps/backend/src/modules/exams/index.ts
@@ -44,9 +44,9 @@ export const exams = new Elysia({
 
   .post(
     "/",
-    async ({ body, user, set }) => {
+    ({ body, user, set }) => {
       set.status = 201;
-      return await ExamService.create(user.sub, body);
+      return ExamService.create(user.sub, body);
     },
     {
       role: "admin",
@@ -78,7 +78,7 @@ export const exams = new Elysia({
   .get(
     "/sessions/:sessionId",
     ({ params: { sessionId }, user }) =>
-      ExamService.getSessionById(sessionId, user.sub, user.role === "admin"),
+      ExamService.getSessionById(sessionId, user),
     {
       auth: true,
       params: ExamModel.SessionIdParam,
@@ -90,7 +90,7 @@ export const exams = new Elysia({
   .put(
     "/sessions/:sessionId",
     ({ params: { sessionId }, body, user }) =>
-      ExamService.saveAnswers(sessionId, user.sub, body.answers),
+      ExamService.saveAnswers(sessionId, user, body.answers),
     {
       auth: true,
       params: ExamModel.SessionIdParam,
@@ -107,7 +107,7 @@ export const exams = new Elysia({
   .post(
     "/sessions/:sessionId/answer",
     ({ params: { sessionId }, body, user }) =>
-      ExamService.submitAnswer(sessionId, user.sub, body),
+      ExamService.submitAnswer(sessionId, user, body),
     {
       auth: true,
       params: ExamModel.SessionIdParam,
@@ -127,7 +127,7 @@ export const exams = new Elysia({
   .post(
     "/sessions/:sessionId/submit",
     ({ params: { sessionId }, user }) =>
-      ExamService.submitExam(sessionId, user.sub),
+      ExamService.submitExam(sessionId, user),
     {
       auth: true,
       params: ExamModel.SessionIdParam,

--- a/apps/backend/src/modules/submissions/index.ts
+++ b/apps/backend/src/modules/submissions/index.ts
@@ -18,36 +18,30 @@ export const submissions = new Elysia({
 })
   .use(authPlugin)
 
-  .get(
-    "/",
-    ({ query, user }) =>
-      SubmissionService.list(query, user.sub, user.role === "admin"),
-    {
-      auth: true,
-      query: t.Object({
-        ...PaginationQuery.properties,
-        skill: t.Optional(Skill),
-        status: t.Optional(SubmissionStatusEnum),
-        userId: t.Optional(t.String({ format: "uuid" })),
+  .get("/", ({ query, user }) => SubmissionService.list(query, user), {
+    auth: true,
+    query: t.Object({
+      ...PaginationQuery.properties,
+      skill: t.Optional(Skill),
+      status: t.Optional(SubmissionStatusEnum),
+      userId: t.Optional(t.String({ format: "uuid" })),
+    }),
+    response: {
+      200: t.Object({
+        data: t.Array(SubmissionModel.SubmissionWithDetails),
+        meta: PaginationMeta,
       }),
-      response: {
-        200: t.Object({
-          data: t.Array(SubmissionModel.SubmissionWithDetails),
-          meta: PaginationMeta,
-        }),
-        ...AuthErrors,
-      },
-      detail: {
-        summary: "List submissions",
-        description: "List submissions with filtering and pagination",
-      },
+      ...AuthErrors,
     },
-  )
+    detail: {
+      summary: "List submissions",
+      description: "List submissions with filtering and pagination",
+    },
+  })
 
   .get(
     "/:id",
-    ({ params, user }) =>
-      SubmissionService.getById(params.id, user.sub, user.role === "admin"),
+    ({ params, user }) => SubmissionService.getById(params.id, user),
     {
       auth: true,
       params: IdParam,
@@ -64,7 +58,7 @@ export const submissions = new Elysia({
 
   .post(
     "/",
-    async ({ body, user, set }) => {
+    ({ body, user, set }) => {
       set.status = 201;
       return SubmissionService.create(user.sub, body);
     },
@@ -86,13 +80,7 @@ export const submissions = new Elysia({
 
   .patch(
     "/:id",
-    ({ params, body, user }) =>
-      SubmissionService.update(
-        params.id,
-        user.sub,
-        user.role === "admin",
-        body,
-      ),
+    ({ params, body, user }) => SubmissionService.update(params.id, user, body),
     {
       auth: true,
       params: IdParam,
@@ -151,8 +139,7 @@ export const submissions = new Elysia({
 
   .delete(
     "/:id",
-    ({ params, user }) =>
-      SubmissionService.remove(params.id, user.sub, user.role === "admin"),
+    ({ params, user }) => SubmissionService.remove(params.id, user),
     {
       auth: true,
       params: IdParam,

--- a/apps/backend/src/modules/users/index.ts
+++ b/apps/backend/src/modules/users/index.ts
@@ -8,7 +8,7 @@ import {
   PaginationQuery,
   SuccessResponse,
 } from "@common/schemas";
-import { assertOwnerOrAdmin } from "@common/utils";
+import { assertAccess } from "@common/utils";
 import { Elysia, t } from "elysia";
 import { authPlugin } from "@/plugins/auth";
 import { UserModel } from "./model";
@@ -22,13 +22,8 @@ export const users = new Elysia({
 
   .get(
     "/:id",
-    async ({ params, user }) => {
-      assertOwnerOrAdmin(
-        params.id,
-        user.sub,
-        user.role === "admin",
-        "You can only view your own profile",
-      );
+    ({ params, user }) => {
+      assertAccess(params.id, user, "You can only view your own profile");
       return UserService.getById(params.id);
     },
     {
@@ -64,7 +59,7 @@ export const users = new Elysia({
 
   .post(
     "/",
-    async ({ body, set }) => {
+    ({ body, set }) => {
       set.status = 201;
       return UserService.create(body);
     },
@@ -81,8 +76,7 @@ export const users = new Elysia({
 
   .patch(
     "/:id",
-    ({ params, body, user }) =>
-      UserService.update(params.id, body, user.sub, user.role === "admin"),
+    ({ params, body, user }) => UserService.update(params.id, body, user),
     {
       auth: true,
       params: IdParam,
@@ -114,12 +108,7 @@ export const users = new Elysia({
   .post(
     "/:id/password",
     ({ params, body, user }) =>
-      UserService.updatePassword(
-        params.id,
-        body,
-        user.sub,
-        user.role === "admin",
-      ),
+      UserService.updatePassword(params.id, body, user),
     {
       auth: true,
       params: IdParam,


### PR DESCRIPTION
- Add Actor interface with is(role) helper for 3-role hierarchy
- Replace assertOwnerOrAdmin(userId, id, isAdmin) with assertAccess(userId, actor)
- Services accept Actor instead of decomposed (currentUserId, isAdmin) params
- Route handlers pass user directly: Service.fn(id, user) vs Service.fn(id, user.sub, user.role === "admin")
- Extract getActiveSession() in ExamService — deduplicates session validation from 3 methods
- Use Drizzle relational query (with: { details: true }) in SubmissionService.getById
- Remove redundant async/return await across all route handlers and transactions
- Remove unused @elysiajs/swagger dependency
- Remove unused _currentUserId param in QuestionService.list
- Remove unused ForbiddenError import in QuestionService
- Fix countResult?.count || 0 → ?? 0 in QuestionService
- QuestionService.restore no longer accepts unused userId/isAdmin params (route is admin-only)

Net: -247 lines, 0 new TS errors, 15/15 tests pass

https://claude.ai/code/session_01Msger4trBn5PNZBRqmy8vX