### PR TITLE
docs: add root CLAUDE.md and rewrite backend CLAUDE.md for current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,264 @@
+# VSTEP Adaptive Learning System
+
+Vietnamese Standardized Test of English Proficiency (VSTEP) exam practice platform with AI grading and adaptive learning. Capstone project (SP26SE145).
+
+## Repository Structure
+
+```
+VSTEP/
+├── apps/
+│   ├── backend/        # Bun + Elysia API server (active development)
+│   ├── frontend/       # Bun + Vite + React (placeholder, not implemented)
+│   └── grading/        # Python + FastAPI + Celery AI grading (placeholder, not implemented)
+├── docs/               # VSTEP exam documentation, capstone specs, sample data
+│   ├── 00-overview/    # Exam structure & scoring system
+│   ├── 01-format/      # Test format overview
+│   ├── 02-writing/     # Writing skills deep-dive
+│   ├── 03-reading/     # Reading format & strategies
+│   ├── 04-listening/   # Listening format & strategies
+│   ├── 05-speaking/    # Speaking format & prompts
+│   ├── 06-scoring/     # Band descriptors & rubrics
+│   ├── capstone/       # Project specs, diagrams, reports
+│   ├── designs/        # UI/UX assets
+│   └── sample/         # Sample exam data (JSON fixtures)
+└── scripts/            # Build & setup scripts
+```
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Runtime | Bun 1.3+ |
+| API Framework | Elysia 1.4+ |
+| Language | TypeScript 5.9+ (strict mode) |
+| Database | PostgreSQL |
+| ORM | Drizzle ORM 0.45+ |
+| Validation | TypeBox (Elysia native) + Zod (env only) |
+| Auth | jose (JWT), Bun.password (Argon2id) |
+| Linter/Formatter | Biome 2.3+ |
+| Testing | bun:test |
+
+## Development Commands
+
+All commands run from `apps/backend/`:
+
+```bash
+bun install              # Install dependencies
+bun run dev              # Start dev server with hot reload
+bun run check            # Lint with Biome
+bun run check --write    # Auto-fix lint issues
+bun run format           # Format code
+bun test                 # Run tests
+
+bun run db:push          # Push schema to DB (development)
+bun run db:generate      # Generate migration files
+bun run db:migrate       # Run migrations
+bun run db:studio        # Open Drizzle Studio GUI
+```
+
+## Critical Rules
+
+### Use Bun, Not Node
+
+- `bun run` not `npm run` / `yarn` / `pnpm`
+- `bun test` not `jest` / `vitest`
+- `bun install` not `npm install`
+- `Bun.password` not `bcrypt` / `argon2`
+- `jose` not `jsonwebtoken`
+- Bun auto-loads `.env` — never use `dotenv`
+
+### Code Quality
+
+- **No `console.log`** — use `logger` from `@common/logger`
+- **No unused imports/variables** — Biome enforces this as error
+- **No import cycles** — Biome enforces `noImportCycles`
+- **No `.js` extensions** in import paths
+- **No barrel re-exports** (`export * from`) in schema files
+- Always run `bun run check` before considering work complete
+
+### Naming Conventions (Biome-enforced)
+
+- Classes, types, interfaces, enums: `PascalCase`
+- Enum members: `PascalCase` or `CONSTANT_CASE`
+- Functions, variables: `camelCase`
+- Constants: `camelCase` or `CONSTANT_CASE`
+
+### Import Aliases
+
+Use path aliases for cross-module imports (never deep relative paths):
+
+```typescript
+import { logger } from "@common/logger";
+import { env } from "@common/env";
+import { db } from "@db/index";
+import { users } from "@db/schema/users";
+import { authPlugin } from "@plugins/auth";
+import { auth } from "@/modules/auth";
+```
+
+| Alias | Maps to |
+|-------|---------|
+| `@/*` | `./src/*` |
+| `@db/*` | `./src/db/*` |
+| `@common/*` | `./src/common/*` |
+| `@plugins/*` | `./src/plugins/*` |
+
+## Backend Architecture
+
+### Module Pattern
+
+Each feature module under `src/modules/{name}/` follows:
+
+| File | Purpose |
+|------|---------|
+| `index.ts` | Elysia routes with auth guards and OpenAPI docs |
+| `model.ts` | TypeBox request/response schemas (namespace pattern) |
+| `service.ts` | Business logic as static methods on a class |
+
+### Modules (6 total)
+
+| Module | Routes Prefix | Key Functionality |
+|--------|--------------|-------------------|
+| `auth` | `/api/auth` | Login, register, refresh token, logout, current user |
+| `users` | `/api/users` | CRUD user management (admin), password changes |
+| `questions` | `/api/questions` | Question bank with versioning (instructor+) |
+| `submissions` | `/api/submissions` | Submit answers, auto/human grading |
+| `exams` | `/api/exams` | Exam sessions, answer tracking, score calculation |
+| `progress` | `/api/progress` | Learning analytics, skill scores, trends |
+
+### Application Entry Points
+
+- `src/index.ts` — Exports the Elysia app
+- `src/app.ts` — App setup: plugins, CORS, health check, module mounting
+- `GET /health` — Health check (PostgreSQL, Redis, RabbitMQ status)
+- All feature routes under `/api/` prefix
+
+### Database Schema (13 tables)
+
+Located in `src/db/schema/`:
+
+| File | Tables |
+|------|--------|
+| `users.ts` | `users`, `refreshTokens` |
+| `questions.ts` | `questions`, `questionVersions` |
+| `submissions.ts` | `submissions`, `submissionDetails`, `submissionEvents` |
+| `exams.ts` | `exams`, `examSessions`, `examAnswers`, `examSubmissions` |
+| `progress.ts` | `userProgress`, `userSkillScores`, `userGoals` |
+| `outbox.ts` | `outbox`, `processedCallbacks` |
+
+Key patterns:
+- Soft deletes via `deletedAt` column with partial indexes
+- `createdAt`/`updatedAt` timestamps on all tables
+- JSONB columns for flexible content (questions, blueprints)
+- 10 PostgreSQL enums for type safety
+
+### Authentication & Authorization
+
+- JWT access tokens (15m) + refresh tokens (7d) with rotation
+- Refresh token reuse detection (compromised tokens revoke all)
+- Three roles with hierarchy: `learner` < `instructor` < `admin`
+- Auth plugin provides `{ auth: true }` and `{ role: "admin" }` macros
+
+### Error Handling
+
+Custom `AppError` hierarchy with structured JSON responses:
+
+```json
+{
+  "requestId": "uuid-v4",
+  "error": { "code": "NOT_FOUND", "message": "User not found" }
+}
+```
+
+Every request gets a `x-request-id` header for tracing.
+
+### API Response Format
+
+```json
+{
+  "data": { ... },
+  "meta": { "page": 1, "limit": 20, "total": 100, "totalPages": 5 }
+}
+```
+
+## Key Source Files
+
+| Purpose | Path |
+|---------|------|
+| App setup | `apps/backend/src/app.ts` |
+| Env config | `apps/backend/src/common/env.ts` |
+| Logger | `apps/backend/src/common/logger.ts` |
+| Shared schemas | `apps/backend/src/common/schemas.ts` |
+| Utilities | `apps/backend/src/common/utils.ts` |
+| DB client | `apps/backend/src/db/index.ts` |
+| DB relations | `apps/backend/src/db/relations.ts` |
+| DB helpers | `apps/backend/src/db/helpers.ts` |
+| Auth plugin | `apps/backend/src/plugins/auth.ts` |
+| Error plugin | `apps/backend/src/plugins/error.ts` |
+| Biome config | `apps/backend/biome.json` |
+| TS config | `apps/backend/tsconfig.json` |
+| Drizzle config | `apps/backend/drizzle.config.ts` |
+
+## Existing Utilities (Use, Don't Recreate)
+
+| Utility | Import | Purpose |
+|---------|--------|---------|
+| `logger` | `@common/logger` | Structured logging (never use `console.log`) |
+| `env` | `@common/env` | Type-safe env vars via `@t3-oss/env-core` |
+| `db` | `@db/index` | Drizzle PostgreSQL client |
+| `authPlugin` | `@plugins/auth` | JWT auth + role-based access macros |
+| `errorPlugin` | `@/plugins/error` | Error handling + request ID tracing |
+| `pagination()` | `@db/helpers` | Pagination with limit/offset + meta builder |
+| `notDeleted()` | `@db/helpers` | Soft-delete filter for queries |
+| `now()` | `@common/utils` | Current timestamp helper |
+| `assertExists()` | `@common/utils` | Throws NotFoundError if null |
+| `assertAccess()` | `@common/utils` | Throws ForbiddenError on ownership mismatch |
+| `escapeLike()` | `@common/utils` | Escape LIKE wildcards for search queries |
+| `Bun.password` | Built-in | Argon2id password hashing/verification |
+
+## Testing
+
+Tests use `bun:test`. Place test files alongside source as `*.test.ts` or in `__tests__/` directories.
+
+```typescript
+import { describe, test, expect } from "bun:test";
+
+describe("feature", () => {
+  test("should work", () => {
+    expect(1 + 1).toBe(2);
+  });
+});
+```
+
+Current coverage is minimal — only `src/plugins/__tests__/auth-final.test.ts` exists (~30 test cases).
+
+## Environment Setup
+
+Copy `apps/backend/.env.example` to `.env` and configure:
+
+```
+DATABASE_URL=postgres://user:password@localhost:5432/vstep
+PORT=3000
+NODE_ENV=development
+JWT_SECRET=<min 32 chars>
+JWT_REFRESH_SECRET=<min 32 chars>
+JWT_EXPIRES_IN=15m
+JWT_REFRESH_EXPIRES_IN=7d
+REDIS_URL=<optional>
+RABBITMQ_URL=<optional>
+```
+
+Bun auto-loads `.env` files — no dotenv needed.
+
+## Verification Checklist
+
+Before completing any task:
+
+- [ ] `bun run check` passes (no lint errors)
+- [ ] `bun test` passes (no test failures)
+- [ ] No `console.log` statements (use `logger`)
+- [ ] Cross-module imports use aliases (`@common`, `@db`, `@plugins`, `@/`)
+- [ ] No `.js` extensions in imports
+- [ ] No unused imports or variables
+- [ ] New schemas follow the namespace pattern in `model.ts`
+- [ ] New routes have OpenAPI `detail` tags and response schemas

--- a/apps/backend/CLAUDE.md
+++ b/apps/backend/CLAUDE.md
@@ -1,111 +1,214 @@
 ---
-description: Use Bun instead of Node.js, npm, pnpm, or vite.
-globs: "*.ts, *.tsx, *.html, *.css, *.js, *.jsx, package.json"
+description: VSTEP Backend — Bun + Elysia + Drizzle + PostgreSQL conventions.
+globs: "*.ts, *.tsx, *.js, *.jsx, package.json, biome.json, tsconfig.json, drizzle.config.ts"
 alwaysApply: false
 ---
 
-Default to using Bun instead of Node.js.
+# VSTEP Backend
 
-- Use `bun <file>` instead of `node <file>` or `ts-node <file>`
-- Use `bun test` instead of `jest` or `vitest`
-- Use `bun build <file.html|file.ts|file.css>` instead of `webpack` or `esbuild`
-- Use `bun install` instead of `npm install` or `yarn install` or `pnpm install`
-- Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
-- Bun automatically loads .env, so don't use dotenv.
+**Stack:** Bun 1.3+ runtime, Elysia 1.4+ framework, Drizzle ORM 0.45+, PostgreSQL, TypeBox validation, Biome linting.
 
-## APIs
+## Use Bun — Not Node
 
-- `Bun.serve()` supports WebSockets, HTTPS, and routes. Don't use `express`.
-- `bun:sqlite` for SQLite. Don't use `better-sqlite3`.
-- `Bun.redis` for Redis. Don't use `ioredis`.
-- `Bun.sql` for Postgres. Don't use `pg` or `postgres.js`.
-- `WebSocket` is built-in. Don't use `ws`.
-- Prefer `Bun.file` over `node:fs`'s readFile/writeFile
-- Bun.$`ls` instead of execa.
+- `bun run dev` / `bun test` / `bun install` — never npm/yarn/pnpm/jest/vitest
+- `Bun.password.hash()` / `.verify()` for passwords — never bcrypt/argon2 packages
+- `jose` for JWT — never jsonwebtoken
+- Bun auto-loads `.env` — never use dotenv
+- `Bun.sql` powers Drizzle — never use pg/postgres.js directly
 
-## Testing
+## Commands
 
-Use `bun test` to run tests.
+```bash
+bun run dev              # Hot-reload dev server
+bun run check            # Biome lint check
+bun run check --write    # Auto-fix lint issues
+bun run format           # Format code
+bun test                 # Run tests
 
-```ts#index.test.ts
-import { test, expect } from "bun:test";
-
-test("hello world", () => {
-  expect(1).toBe(1);
-});
+bun run db:push          # Push schema to DB (dev)
+bun run db:generate      # Generate migrations
+bun run db:migrate       # Run migrations
+bun run db:studio        # Drizzle Studio GUI
 ```
 
-## Frontend
+## Import Aliases
 
-Use HTML imports with `Bun.serve()`. Don't use `vite`. HTML imports fully support React, CSS, Tailwind.
+```typescript
+import { logger } from "@common/logger";
+import { env } from "@common/env";
+import { db } from "@db/index";
+import { users } from "@db/schema/users";
+import { authPlugin } from "@plugins/auth";
+import { auth } from "@/modules/auth";
 
-Server:
+// Within same module — relative imports are fine
+import { helper } from "./utils/helper";
+```
 
-```ts#index.ts
-import index from "./index.html"
+| Alias | Maps to |
+|-------|---------|
+| `@/*` | `./src/*` |
+| `@db/*` | `./src/db/*` |
+| `@common/*` | `./src/common/*` |
+| `@plugins/*` | `./src/plugins/*` |
 
-Bun.serve({
-  routes: {
-    "/": index,
-    "/api/users/:id": {
-      GET: (req) => {
-        return new Response(JSON.stringify({ id: req.params.id }));
-      },
-    },
-  },
-  // optional websocket support
-  websocket: {
-    open: (ws) => {
-      ws.send("Hello, world!");
-    },
-    message: (ws, message) => {
-      ws.send(message);
-    },
-    close: (ws) => {
-      // handle close
-    }
-  },
-  development: {
-    hmr: true,
-    console: true,
+## File Locations
+
+| Type | Path | Pattern |
+|------|------|---------|
+| Module routes | `src/modules/{name}/index.ts` | Elysia routes + auth guards |
+| Module schemas | `src/modules/{name}/model.ts` | TypeBox schemas in namespace |
+| Module logic | `src/modules/{name}/service.ts` | Static methods on a class |
+| DB schema | `src/db/schema/{name}.ts` | Drizzle pgTable definitions |
+| DB relations | `src/db/relations.ts` | Drizzle relational queries setup |
+| DB helpers | `src/db/helpers.ts` | `pagination()`, `notDeleted()` |
+| Plugins | `src/plugins/{name}.ts` | Elysia plugins (auth, error) |
+| Shared utils | `src/common/{name}.ts` | Logger, env, schemas, utils |
+| Tests | `src/**/*.test.ts` or `src/**/__tests__/` | bun:test |
+
+## Existing Utilities (Use, Don't Recreate)
+
+| Utility | Import | Purpose |
+|---------|--------|---------|
+| `logger` | `@common/logger` | Structured logging — never `console.log` |
+| `env` | `@common/env` | Type-safe env vars (`@t3-oss/env-core` + Zod) |
+| `db` | `@db/index` | Drizzle PostgreSQL client |
+| `authPlugin` | `@plugins/auth` | JWT bearer auth + role macros |
+| `errorPlugin` | `@/plugins/error` | Error handling + request ID tracing |
+| `pagination()` | `@db/helpers` | Pagination offset/limit + meta builder |
+| `notDeleted()` | `@db/helpers` | Soft-delete WHERE filter |
+| `now()` | `@common/utils` | Current timestamp |
+| `assertExists()` | `@common/utils` | Throws NotFoundError if null |
+| `assertAccess()` | `@common/utils` | Throws ForbiddenError on ownership mismatch |
+| `escapeLike()` | `@common/utils` | Escape SQL LIKE wildcards |
+| Shared enums | `@common/enums` | Skill, Role, Band, etc. (from pgEnums) |
+| Shared schemas | `@common/schemas` | Pagination params, error responses |
+
+## Patterns
+
+### Module Route
+
+```typescript
+import { Elysia } from "elysia";
+import { authPlugin } from "@plugins/auth";
+import { FeatureService } from "./service";
+import { Feature } from "./model";
+
+export const feature = new Elysia({ prefix: "/feature" })
+  .use(authPlugin())
+  .get("/", ({ query }) => FeatureService.list(query), {
+    auth: true,
+    query: Feature.ListQuery,
+    response: { 200: Feature.ListResponse },
+    detail: { tags: ["Feature"], summary: "List features" },
+  });
+```
+
+### Service Class
+
+```typescript
+import { db } from "@db/index";
+import { features } from "@db/schema/features";
+import { eq } from "drizzle-orm";
+
+export class FeatureService {
+  static async list(query: { page?: number; limit?: number }) {
+    // business logic with Drizzle queries
   }
-})
-```
 
-HTML files can import .tsx, .jsx or .js files directly and Bun's bundler will transpile & bundle automatically. `<link>` tags can point to stylesheets and Bun's CSS bundler will bundle.
-
-```html#index.html
-<html>
-  <body>
-    <h1>Hello, world!</h1>
-    <script type="module" src="./frontend.tsx"></script>
-  </body>
-</html>
-```
-
-With the following `frontend.tsx`:
-
-```tsx#frontend.tsx
-import React from "react";
-
-// import .css files directly and it works
-import './index.css';
-
-import { createRoot } from "react-dom/client";
-
-const root = createRoot(document.body);
-
-export default function Frontend() {
-  return <h1>Hello, world!</h1>;
+  static async getById(id: string) {
+    const result = await db.query.features.findFirst({
+      where: eq(features.id, id),
+    });
+    return assertExists(result, "Feature");
+  }
 }
-
-root.render(<Frontend />);
 ```
 
-Then, run index.ts
+### Model Schema (TypeBox namespace)
 
-```sh
-bun --hot ./index.ts
+```typescript
+import { t } from "elysia";
+
+export namespace Feature {
+  export const ListQuery = t.Object({
+    page: t.Optional(t.Number({ minimum: 1 })),
+    limit: t.Optional(t.Number({ minimum: 1, maximum: 100 })),
+  });
+
+  export const ListResponse = t.Object({
+    data: t.Array(t.Object({ id: t.String(), name: t.String() })),
+    meta: t.Object({ page: t.Number(), limit: t.Number(), total: t.Number() }),
+  });
+}
 ```
 
-For more information, read the Bun API docs in `node_modules/bun-types/docs/**.md`.
+### DB Schema
+
+```typescript
+import { pgTable, uuid, varchar, timestamp } from "drizzle-orm/pg-core";
+
+export const features = pgTable("features", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  name: varchar("name", { length: 255 }).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().$onUpdate(() => new Date()).notNull(),
+  deletedAt: timestamp("deleted_at"),
+});
+
+export type Feature = typeof features.$inferSelect;
+export type NewFeature = typeof features.$inferInsert;
+```
+
+### Auth Guards
+
+```typescript
+// Require authenticated user
+.get("/", handler, { auth: true })
+
+// Require specific role (hierarchy: learner < instructor < admin)
+.post("/", handler, { role: "instructor" })
+.delete("/:id", handler, { role: "admin" })
+```
+
+### Logging
+
+```typescript
+import { logger } from "@common/logger";
+
+logger.info("Event description", { key: "value" });
+logger.error("Something failed", { error: err.message });
+// Never use console.log — Biome warns on it
+```
+
+## Golden Rules
+
+1. **No `.js` in imports** — TypeScript only, no extensions
+2. **No barrel re-exports** — No `export * from` in schema files
+3. **No banned packages** — No bcrypt, jsonwebtoken, ioredis, dotenv, pg, jest
+4. **Cross-module = aliases** — Always use `@common/`, `@db/`, `@plugins/`, `@/`
+5. **Soft deletes** — Use `deletedAt` + `notDeleted()` filter, never hard delete
+6. **Static service methods** — Services are classes with only static methods
+7. **TypeBox for API validation** — Not Zod (Zod is only for env config)
+8. **OpenAPI detail on every route** — Include `tags` and `summary`
+
+## Naming Conventions (Biome-enforced)
+
+- Types, interfaces, classes, enums: `PascalCase`
+- Enum members: `PascalCase` or `CONSTANT_CASE`
+- Functions, variables: `camelCase`
+- Constants: `camelCase` or `CONSTANT_CASE`
+- Object properties: `camelCase` or `CONSTANT_CASE`
+
+## Verification
+
+Before completing any task:
+
+- [ ] `bun run check` passes
+- [ ] `bun test` passes
+- [ ] No `console.log` (use `logger`)
+- [ ] Cross-module imports use aliases
+- [ ] No `.js` extensions in imports
+- [ ] No unused imports or variables
+- [ ] Routes have OpenAPI `detail` with tags and summary
+- [ ] New DB tables include `createdAt`, `updatedAt`, and `deletedAt`


### PR DESCRIPTION
Create a comprehensive root-level CLAUDE.md covering the full monorepo:
repository structure, tech stack, development commands, import conventions,
module architecture, database schema overview, auth patterns, and
verification checklist.

Rewrite apps/backend/CLAUDE.md from a generic Bun reference to a
project-specific guide reflecting the actual stack (Elysia, Drizzle,
TypeBox, PostgreSQL) with accurate patterns, utilities inventory,
golden rules, and code examples matching the codebase conventions.

https://claude.ai/code/session_01SuKaWXxjDzUnBr7mN5SEMf