### PR TITLE
wip: refactor auth + users — internalize JWT logic, thin routes, consistent patterns

### DIFF
--- a/apps/backend/src/db/helpers.ts
+++ b/apps/backend/src/db/helpers.ts
@@ -4,6 +4,26 @@ export function notDeleted<T extends { deletedAt: unknown }>(table: T): SQL {
   return isNull(table.deletedAt);
 }
 
+/** Pick only the listed keys from a getTableColumns() result */
+export function pickColumns<
+  T extends Record<string, unknown>,
+  K extends keyof T,
+>(columns: T, keys: K[]): Pick<T, K> {
+  const result = {} as Pick<T, K>;
+  for (const key of keys) result[key] = columns[key];
+  return result;
+}
+
+/** Omit the listed keys from a getTableColumns() result */
+export function omitColumns<
+  T extends Record<string, unknown>,
+  K extends keyof T,
+>(columns: T, keys: K[]): Omit<T, K> {
+  const result = { ...columns };
+  for (const key of keys) delete result[key];
+  return result as Omit<T, K>;
+}
+
 /**
  * Combined pagination helper — returns limit, offset, and a meta() builder.
  * Replaces the old paginate() + paginationMeta() pair.

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -13,7 +13,7 @@ export const db = drizzle(env.DATABASE_URL, {
 });
 
 export { table };
-export { notDeleted, pagination } from "./helpers";
+export { notDeleted, omitColumns, pagination, pickColumns } from "./helpers";
 
 /** Transaction type derived from the db client — use instead of fragile Parameters<> extraction */
 export type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];

--- a/apps/backend/src/modules/auth/index.ts
+++ b/apps/backend/src/modules/auth/index.ts
@@ -19,10 +19,7 @@ export const auth = new Elysia({ prefix: "/auth", detail: { tags: ["Auth"] } })
   .post(
     "/login",
     ({ body, request }) =>
-      login({
-        ...body,
-        deviceInfo: request.headers.get("user-agent") ?? undefined,
-      }),
+      login(body, request.headers.get("user-agent") ?? undefined),
     {
       body: AuthLoginBody,
       response: {
@@ -60,10 +57,10 @@ export const auth = new Elysia({ prefix: "/auth", detail: { tags: ["Auth"] } })
   .post(
     "/refresh",
     ({ body, request }) =>
-      refresh({
-        refreshToken: body.refreshToken,
-        deviceInfo: request.headers.get("user-agent") ?? undefined,
-      }),
+      refresh(
+        body.refreshToken,
+        request.headers.get("user-agent") ?? undefined,
+      ),
     {
       body: AuthRefreshBody,
       response: {

--- a/apps/backend/src/modules/exams/model.ts
+++ b/apps/backend/src/modules/exams/model.ts
@@ -59,8 +59,16 @@ export const ExamAnswerSaveBody = t.Object({
   ),
 });
 
+export const ExamListQuery = t.Object({
+  page: t.Optional(t.Number({ minimum: 1, default: 1 })),
+  limit: t.Optional(t.Number({ minimum: 1, maximum: 100, default: 20 })),
+  level: t.Optional(QuestionLevel),
+  isActive: t.Optional(t.Boolean()),
+});
+
 export type ExamSchema = typeof ExamSchema.static;
 export type ExamSessionSchema = typeof ExamSessionSchema.static;
 export type ExamCreateBody = typeof ExamCreateBody.static;
 export type ExamUpdateBody = typeof ExamUpdateBody.static;
 export type ExamAnswerSaveBody = typeof ExamAnswerSaveBody.static;
+export type ExamListQuery = typeof ExamListQuery.static;

--- a/apps/backend/src/modules/progress/index.ts
+++ b/apps/backend/src/modules/progress/index.ts
@@ -22,22 +22,31 @@ export const progress = new Elysia({
   .get("/", ({ user }) => getProgressOverview(user.sub), {
     auth: true,
     response: { 200: ProgressOverviewResponse, ...AuthErrors },
-    detail: { summary: "Get progress overview (all skills)" },
+    detail: {
+      summary: "Get progress overview",
+      description: "Get progress overview for all skills",
+    },
   })
 
   .get("/spider-chart", ({ user }) => getSpiderChart(user.sub), {
     auth: true,
     response: { 200: ProgressSpiderChartResponse, ...AuthErrors },
-    detail: { summary: "Get spider chart data for all skills" },
+    detail: {
+      summary: "Get spider chart",
+      description: "Get spider chart data for all skills",
+    },
   })
 
   .get(
     "/:skill",
-    ({ params: { skill }, user }) => getProgressBySkill(skill, user.sub),
+    ({ params, user }) => getProgressBySkill(user.sub, params.skill),
     {
       auth: true,
       params: t.Object({ skill: Skill }),
       response: { 200: ProgressSkillDetailResponse, ...AuthErrors },
-      detail: { summary: "Get progress for a specific skill" },
+      detail: {
+        summary: "Get skill progress",
+        description: "Get detailed progress for a specific skill",
+      },
     },
   );

--- a/apps/backend/src/modules/progress/service.ts
+++ b/apps/backend/src/modules/progress/service.ts
@@ -2,6 +2,8 @@ import { and, desc, eq, inArray } from "drizzle-orm";
 import type { UserProgress } from "@/db";
 import { db, table } from "@/db";
 
+// ── Pure functions ──────────────────────────────────────────────────
+
 type Trend =
   | "improving"
   | "stable"
@@ -27,49 +29,48 @@ export function computeTrend(scores: number[], stdDev: number | null): Trend {
   return "insufficient_data";
 }
 
-/** Overview: all 4 skills with latest stats */
+// ── Public API ──────────────────────────────────────────────────────
+
 export async function getProgressOverview(userId: string) {
-  const records = await db.query.userProgress.findMany({
-    where: eq(table.userProgress.userId, userId),
-  });
+  const [records, goal] = await Promise.all([
+    db.query.userProgress.findMany({
+      where: eq(table.userProgress.userId, userId),
+    }),
+    db.query.userGoals.findFirst({
+      where: eq(table.userGoals.userId, userId),
+      orderBy: desc(table.userGoals.createdAt),
+    }),
+  ]);
 
-  const goal = await db.query.userGoals.findFirst({
-    where: eq(table.userGoals.userId, userId),
-    orderBy: desc(table.userGoals.createdAt),
-  });
-
-  return {
-    skills: records,
-    goal: goal ?? null,
-  };
+  return { skills: records, goal: goal ?? null };
 }
 
-/** Single skill detail with sliding window */
 export async function getProgressBySkill(
-  skill: UserProgress["skill"],
   userId: string,
+  skill: UserProgress["skill"],
 ) {
-  const progress = await db.query.userProgress.findFirst({
-    where: and(
-      eq(table.userProgress.userId, userId),
-      eq(table.userProgress.skill, skill),
-    ),
-  });
-
-  const recentScores = await db
-    .select({
-      score: table.userSkillScores.score,
-      createdAt: table.userSkillScores.createdAt,
-    })
-    .from(table.userSkillScores)
-    .where(
-      and(
-        eq(table.userSkillScores.userId, userId),
-        eq(table.userSkillScores.skill, skill),
+  const [progress, recentScores] = await Promise.all([
+    db.query.userProgress.findFirst({
+      where: and(
+        eq(table.userProgress.userId, userId),
+        eq(table.userProgress.skill, skill),
       ),
-    )
-    .orderBy(desc(table.userSkillScores.createdAt))
-    .limit(10);
+    }),
+    db
+      .select({
+        score: table.userSkillScores.score,
+        createdAt: table.userSkillScores.createdAt,
+      })
+      .from(table.userSkillScores)
+      .where(
+        and(
+          eq(table.userSkillScores.userId, userId),
+          eq(table.userSkillScores.skill, skill),
+        ),
+      )
+      .orderBy(desc(table.userSkillScores.createdAt))
+      .limit(10),
+  ]);
 
   const scores = recentScores.map((r) => r.score);
   const windowAvg =
@@ -85,23 +86,19 @@ export async function getProgressBySkill(
         )
       : null;
 
-  const trend = computeTrend(scores, windowStdDev);
-
   return {
     progress: progress ?? null,
     recentScores,
     windowAvg: windowAvg !== null ? Math.round(windowAvg * 10) / 10 : null,
     windowStdDev:
       windowStdDev !== null ? Math.round(windowStdDev * 100) / 100 : null,
-    trend,
+    trend: computeTrend(scores, windowStdDev),
   };
 }
 
-/** Spider chart data — batch query (2 queries instead of 8) */
 export async function getSpiderChart(userId: string) {
   const skills = ["listening", "reading", "writing", "speaking"] as const;
 
-  // Batch: all recent scores + goal in 2 queries
   const [allScores, goal] = await Promise.all([
     db
       .select({
@@ -123,7 +120,6 @@ export async function getSpiderChart(userId: string) {
     }),
   ]);
 
-  // Group scores by skill (keep last 10 per skill)
   const scoresBySkill = new Map<string, number[]>();
   for (const row of allScores) {
     const arr = scoresBySkill.get(row.skill) ?? [];
@@ -152,8 +148,5 @@ export async function getSpiderChart(userId: string) {
     };
   }
 
-  return {
-    skills: result,
-    goal: goal ?? null,
-  };
+  return { skills: result, goal: goal ?? null };
 }

--- a/apps/backend/src/modules/questions/model.ts
+++ b/apps/backend/src/modules/questions/model.ts
@@ -59,8 +59,20 @@ export const QuestionVersionBody = t.Object({
   answerKey: t.Optional(ObjectiveAnswerKey),
 });
 
+export const QuestionListQuery = t.Object({
+  page: t.Optional(t.Number({ minimum: 1, default: 1 })),
+  limit: t.Optional(t.Number({ minimum: 1, maximum: 100, default: 20 })),
+  skill: t.Optional(Skill),
+  level: t.Optional(QuestionLevel),
+  format: t.Optional(QuestionFormat),
+  isActive: t.Optional(t.Boolean()),
+  search: t.Optional(t.String()),
+});
+
 export type QuestionSchema = typeof QuestionSchema.static;
 export type QuestionWithDetailsSchema = typeof QuestionWithDetailsSchema.static;
 export type QuestionVersionSchema = typeof QuestionVersionSchema.static;
 export type QuestionCreateBody = typeof QuestionCreateBody.static;
 export type QuestionUpdateBody = typeof QuestionUpdateBody.static;
+export type QuestionListQuery = typeof QuestionListQuery.static;
+export type QuestionVersionBody = typeof QuestionVersionBody.static;

--- a/apps/backend/src/modules/submissions/index.ts
+++ b/apps/backend/src/modules/submissions/index.ts
@@ -1,11 +1,9 @@
-import { Skill, SubmissionStatus as SubmissionStatusEnum } from "@common/enums";
 import {
   AuthErrors,
   CrudErrors,
   ErrorResponse,
   IdParam,
   PaginationMeta,
-  PaginationQuery,
 } from "@common/schemas";
 import { Elysia, t } from "elysia";
 import { AutoGradeResult } from "@/modules/questions/content-schemas";
@@ -13,6 +11,7 @@ import { authPlugin } from "@/plugins/auth";
 import {
   SubmissionCreateBody,
   SubmissionGradeBody,
+  SubmissionListQuery,
   SubmissionUpdateBody,
   SubmissionWithDetailsSchema,
 } from "./model";
@@ -34,12 +33,7 @@ export const submissions = new Elysia({
 
   .get("/", ({ query, user }) => listSubmissions(query, user), {
     auth: true,
-    query: t.Object({
-      ...PaginationQuery.properties,
-      skill: t.Optional(Skill),
-      status: t.Optional(SubmissionStatusEnum),
-      userId: t.Optional(t.String({ format: "uuid" })),
-    }),
+    query: SubmissionListQuery,
     response: {
       200: t.Object({
         data: t.Array(SubmissionWithDetailsSchema),
@@ -90,7 +84,7 @@ export const submissions = new Elysia({
 
   .patch(
     "/:id",
-    ({ params, body, user }) => updateSubmission(params.id, user, body),
+    ({ params, body, user }) => updateSubmission(params.id, body, user),
     {
       auth: true,
       params: IdParam,
@@ -143,7 +137,10 @@ export const submissions = new Elysia({
     auth: true,
     params: IdParam,
     response: {
-      200: t.Object({ id: t.String({ format: "uuid" }) }),
+      200: t.Object({
+        id: t.String({ format: "uuid" }),
+        deletedAt: t.String({ format: "date-time" }),
+      }),
       ...CrudErrors,
     },
     detail: {

--- a/apps/backend/src/modules/submissions/model.ts
+++ b/apps/backend/src/modules/submissions/model.ts
@@ -50,8 +50,18 @@ export const SubmissionGradeBody = t.Object({
   feedback: t.Optional(t.String({ maxLength: 10000 })),
 });
 
+export const SubmissionListQuery = t.Object({
+  page: t.Optional(t.Number({ minimum: 1, default: 1 })),
+  limit: t.Optional(t.Number({ minimum: 1, maximum: 100, default: 20 })),
+  skill: t.Optional(Skill),
+  status: t.Optional(SubmissionStatusEnum),
+  userId: t.Optional(t.String({ format: "uuid" })),
+});
+
 export type SubmissionSchema = typeof SubmissionSchema.static;
 export type SubmissionWithDetailsSchema =
   typeof SubmissionWithDetailsSchema.static;
 export type SubmissionCreateBody = typeof SubmissionCreateBody.static;
 export type SubmissionUpdateBody = typeof SubmissionUpdateBody.static;
+export type SubmissionGradeBody = typeof SubmissionGradeBody.static;
+export type SubmissionListQuery = typeof SubmissionListQuery.static;

--- a/apps/backend/src/modules/users/model.ts
+++ b/apps/backend/src/modules/users/model.ts
@@ -41,7 +41,15 @@ export const UserPasswordBody = t.Object({
   }),
 });
 
+export const UserListQuery = t.Object({
+  page: t.Optional(t.Number({ minimum: 1, default: 1 })),
+  limit: t.Optional(t.Number({ minimum: 1, maximum: 100, default: 20 })),
+  role: t.Optional(UserRole),
+  search: t.Optional(t.String()),
+});
+
 export type UserSchema = typeof UserSchema.static;
 export type UserCreateBody = typeof UserCreateBody.static;
 export type UserUpdateBody = typeof UserUpdateBody.static;
 export type UserPasswordBody = typeof UserPasswordBody.static;
+export type UserListQuery = typeof UserListQuery.static;

--- a/apps/backend/src/modules/users/service.ts
+++ b/apps/backend/src/modules/users/service.ts
@@ -9,7 +9,7 @@ import {
   ne,
   type SQL,
 } from "drizzle-orm";
-import { db, notDeleted, pagination, table } from "@/db";
+import { db, notDeleted, omitColumns, pagination, table } from "@/db";
 import type { Actor } from "@/plugins/auth";
 import {
   ConflictError,
@@ -17,12 +17,19 @@ import {
   isUniqueViolation,
   UnauthorizedError,
 } from "@/plugins/error";
+import type {
+  UserCreateBody,
+  UserListQuery,
+  UserPasswordBody,
+  UserUpdateBody,
+} from "./model";
 
-const {
-  passwordHash: _passwordHash,
-  deletedAt: _deletedAt,
-  ...USER_COLUMNS
-} = getTableColumns(table.users);
+// ── Column sets ─────────────────────────────────────────────────────
+
+const USER_COLUMNS = omitColumns(getTableColumns(table.users), [
+  "passwordHash",
+  "deletedAt",
+]);
 
 // ── Public API ──────────────────────────────────────────────────────
 
@@ -46,20 +53,13 @@ export async function getUserById(userId: string, actor?: Actor) {
   return assertExists(user, "User");
 }
 
-export async function listUsers(query: {
-  page?: number;
-  limit?: number;
-  role?: "learner" | "instructor" | "admin";
-  search?: string;
-}) {
+export async function listUsers(query: UserListQuery) {
   const pg = pagination(query.page, query.limit);
-
   const conditions: SQL[] = [notDeleted(table.users)];
 
   if (query.role) {
     conditions.push(eq(table.users.role, query.role));
   }
-
   if (query.search) {
     conditions.push(
       ilike(table.users.fullName, `%${escapeLike(query.search)}%`),
@@ -68,33 +68,21 @@ export async function listUsers(query: {
 
   const whereClause = and(...conditions);
 
-  const [countResult] = await db
-    .select({ count: count() })
-    .from(table.users)
-    .where(whereClause);
+  const [[countResult], users] = await Promise.all([
+    db.select({ count: count() }).from(table.users).where(whereClause),
+    db
+      .select(USER_COLUMNS)
+      .from(table.users)
+      .where(whereClause)
+      .orderBy(table.users.createdAt)
+      .limit(pg.limit)
+      .offset(pg.offset),
+  ]);
 
-  const total = countResult?.count ?? 0;
-
-  const users = await db
-    .select(USER_COLUMNS)
-    .from(table.users)
-    .where(whereClause)
-    .orderBy(table.users.createdAt)
-    .limit(pg.limit)
-    .offset(pg.offset);
-
-  return {
-    data: users,
-    meta: pg.meta(total),
-  };
+  return { data: users, meta: pg.meta(countResult?.count ?? 0) };
 }
 
-export async function createUser(body: {
-  email: string;
-  password: string;
-  fullName?: string;
-  role?: "learner" | "instructor" | "admin";
-}) {
+export async function createUser(body: UserCreateBody) {
   const passwordHash = await hashPassword(body.password);
 
   try {
@@ -119,11 +107,7 @@ export async function createUser(body: {
 
 export async function updateUser(
   userId: string,
-  body: {
-    email?: string;
-    fullName?: string | null;
-    role?: "learner" | "instructor" | "admin";
-  },
+  body: UserUpdateBody,
   actor: Actor,
 ) {
   assertAccess(userId, actor, "You can only update your own profile");
@@ -133,27 +117,23 @@ export async function updateUser(
   }
 
   return db.transaction(async (tx) => {
-    const [existingUser] = await tx
-      .select({ id: table.users.id })
-      .from(table.users)
-      .where(and(eq(table.users.id, userId), notDeleted(table.users)))
-      .limit(1);
-
-    assertExists(existingUser, "User");
+    assertExists(
+      await tx.query.users.findFirst({
+        where: and(eq(table.users.id, userId), notDeleted(table.users)),
+        columns: { id: true },
+      }),
+      "User",
+    );
 
     if (body.email) {
-      const [emailExists] = await tx
-        .select({ id: table.users.id })
-        .from(table.users)
-        .where(
-          and(
-            eq(table.users.email, body.email),
-            ne(table.users.id, userId),
-            notDeleted(table.users),
-          ),
-        )
-        .limit(1);
-
+      const emailExists = await tx.query.users.findFirst({
+        where: and(
+          eq(table.users.email, body.email),
+          ne(table.users.id, userId),
+          notDeleted(table.users),
+        ),
+        columns: { id: true },
+      });
       if (emailExists) {
         throw new ConflictError("Email already in use");
       }
@@ -162,7 +142,6 @@ export async function updateUser(
     const updateValues: Partial<typeof table.users.$inferInsert> = {
       updatedAt: now(),
     };
-
     if (body.email) updateValues.email = body.email;
     if (body.fullName !== undefined) updateValues.fullName = body.fullName;
     if (body.role) updateValues.role = body.role;
@@ -179,72 +158,54 @@ export async function updateUser(
 
 export async function removeUser(userId: string) {
   return db.transaction(async (tx) => {
-    const [existingUser] = await tx
-      .select({ id: table.users.id })
-      .from(table.users)
-      .where(and(eq(table.users.id, userId), notDeleted(table.users)))
-      .limit(1);
-
-    assertExists(existingUser, "User");
+    assertExists(
+      await tx.query.users.findFirst({
+        where: and(eq(table.users.id, userId), notDeleted(table.users)),
+        columns: { id: true },
+      }),
+      "User",
+    );
 
     const timestamp = now();
     const [user] = await tx
       .update(table.users)
-      .set({
-        deletedAt: timestamp,
-        updatedAt: timestamp,
-      })
+      .set({ deletedAt: timestamp, updatedAt: timestamp })
       .where(eq(table.users.id, userId))
-      .returning({
-        id: table.users.id,
-        deletedAt: table.users.deletedAt,
-      });
+      .returning({ id: table.users.id, deletedAt: table.users.deletedAt });
 
-    const deletedUser = assertExists(user, "User");
-
-    return {
-      id: deletedUser.id,
-      deletedAt: deletedUser.deletedAt ?? timestamp,
-    };
+    const deleted = assertExists(user, "User");
+    return { id: deleted.id, deletedAt: deleted.deletedAt ?? timestamp };
   });
 }
 
 export async function updateUserPassword(
   userId: string,
-  body: { currentPassword: string; newPassword: string },
+  body: UserPasswordBody,
   actor: Actor,
 ) {
   assertAccess(userId, actor, "You can only change your own password");
 
   return db.transaction(async (tx) => {
-    const [row] = await tx
-      .select({
-        id: table.users.id,
-        passwordHash: table.users.passwordHash,
-      })
-      .from(table.users)
-      .where(and(eq(table.users.id, userId), notDeleted(table.users)))
-      .limit(1);
-
-    const user = assertExists(row, "User");
+    const user = assertExists(
+      await tx.query.users.findFirst({
+        where: and(eq(table.users.id, userId), notDeleted(table.users)),
+        columns: { id: true, passwordHash: true },
+      }),
+      "User",
+    );
 
     const isValid = await verifyPassword(
       body.currentPassword,
       user.passwordHash,
     );
-
     if (!isValid) {
       throw new UnauthorizedError("Current password is incorrect");
     }
 
     const newPasswordHash = await hashPassword(body.newPassword);
-
     await tx
       .update(table.users)
-      .set({
-        passwordHash: newPasswordHash,
-        updatedAt: now(),
-      })
+      .set({ passwordHash: newPasswordHash, updatedAt: now() })
       .where(eq(table.users.id, userId));
 
     return { message: "Password updated successfully" };


### PR DESCRIPTION
Auth:
- Move signAccessToken/parseExpiry/hashToken to internal (not exported)
- login/refresh now return complete token response (no JWT logic in routes)
- Rename refreshToken() to refresh() for consistency
- Routes are now thin pass-throughs

Users:
- getUserById accepts optional actor for access control (moved from route)

https://claude.ai/code/session_01Xzn8vZ3R4FVm5zb5S7r1RC