### PR TITLE
Add VSTEP exam blueprint validation and tests; integrate into exam service

### DIFF
--- a/apps/backend/src/modules/exams/blueprint-validation.test.ts
+++ b/apps/backend/src/modules/exams/blueprint-validation.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "bun:test";
+import { BadRequestError } from "@common/errors";
+import type { ExamBlueprint } from "@db/types/exam-blueprint";
+import type { QuestionContent } from "@db/types/question-content";
+import { validateVstepExamBlueprint } from "./blueprint-validation";
+
+type BlueprintQuestion = {
+  id: string;
+  skill: "listening" | "reading" | "writing" | "speaking";
+  part: number;
+  content: QuestionContent;
+};
+
+function makeListeningQuestion(
+  id: string,
+  part: 1 | 2 | 3,
+  itemCount: number,
+): BlueprintQuestion {
+  return {
+    id,
+    skill: "listening",
+    part,
+    content: {
+      audioUrl: "https://example.com/audio.mp3",
+      items: Array.from({ length: itemCount }, () => ({
+        stem: "Question",
+        options: ["A", "B", "C", "D"],
+      })),
+    },
+  };
+}
+
+function makeReadingQuestion(
+  id: string,
+  part: 1 | 2 | 3 | 4,
+  itemCount: number,
+): BlueprintQuestion {
+  return {
+    id,
+    skill: "reading",
+    part,
+    content: {
+      passage: "Passage",
+      items: Array.from({ length: itemCount }, () => ({
+        stem: "Question",
+        options: ["A", "B", "C", "D"],
+      })),
+    },
+  };
+}
+
+function makeWritingQuestion(
+  id: string,
+  part: 1 | 2,
+  minWords: number,
+): BlueprintQuestion {
+  return {
+    id,
+    skill: "writing",
+    part,
+    content: {
+      prompt: "Write",
+      taskType: part === 1 ? "letter" : "essay",
+      minWords,
+    },
+  };
+}
+
+function makeSpeakingQuestion(id: string, part: 1 | 2 | 3): BlueprintQuestion {
+  if (part === 1) {
+    return {
+      id,
+      skill: "speaking",
+      part,
+      content: {
+        topics: [
+          { name: "Topic 1", questions: ["Q1", "Q2", "Q3"] },
+          { name: "Topic 2", questions: ["Q1", "Q2", "Q3"] },
+        ],
+      },
+    };
+  }
+
+  if (part === 2) {
+    return {
+      id,
+      skill: "speaking",
+      part,
+      content: {
+        situation: "Situation",
+        options: ["Opt 1", "Opt 2", "Opt 3"],
+        preparationSeconds: 60,
+        speakingSeconds: 120,
+      },
+    };
+  }
+
+  return {
+    id,
+    skill: "speaking",
+    part,
+    content: {
+      centralIdea: "Idea",
+      suggestions: ["A", "B", "C"],
+      followUpQuestion: "Follow up",
+      preparationSeconds: 60,
+      speakingSeconds: 300,
+    },
+  };
+}
+
+function makeValidDataset() {
+  const questions: BlueprintQuestion[] = [
+    makeListeningQuestion("l1", 1, 8),
+    makeListeningQuestion("l2", 2, 12),
+    makeListeningQuestion("l3", 3, 15),
+    makeReadingQuestion("r1", 1, 10),
+    makeReadingQuestion("r2", 2, 10),
+    makeReadingQuestion("r3", 3, 10),
+    makeReadingQuestion("r4", 4, 10),
+    makeWritingQuestion("w1", 1, 120),
+    makeWritingQuestion("w2", 2, 250),
+    makeSpeakingQuestion("s1", 1),
+    makeSpeakingQuestion("s2", 2),
+    makeSpeakingQuestion("s3", 3),
+  ];
+
+  const blueprint: ExamBlueprint = {
+    listening: { questionIds: ["l1", "l2", "l3"] },
+    reading: { questionIds: ["r1", "r2", "r3", "r4"] },
+    writing: { questionIds: ["w1", "w2"] },
+    speaking: { questionIds: ["s1", "s2", "s3"] },
+  };
+
+  return { blueprint, questions };
+}
+
+describe("validateVstepExamBlueprint", () => {
+  it("accepts full valid VSTEP structure", () => {
+    const { blueprint, questions } = makeValidDataset();
+    expect(() => validateVstepExamBlueprint(blueprint, questions)).not.toThrow();
+  });
+
+  it("rejects listening total different from 35", () => {
+    const { blueprint, questions } = makeValidDataset();
+    const listeningPart3 = questions.find((question) => question.id === "l3");
+    if (!listeningPart3) throw new Error("missing fixture question l3");
+
+    listeningPart3.content = {
+      audioUrl: "https://example.com/audio.mp3",
+      items: Array.from({ length: 14 }, () => ({
+        stem: "Question",
+        options: ["A", "B", "C", "D"],
+      })),
+    };
+
+    expect(() => validateVstepExamBlueprint(blueprint, questions)).toThrow(
+      BadRequestError,
+    );
+  });
+
+  it("rejects reading structure that is not 4x10", () => {
+    const { blueprint, questions } = makeValidDataset();
+    const readingPart4 = questions.find((question) => question.id === "r4");
+    if (!readingPart4) throw new Error("missing fixture question r4");
+
+    readingPart4.content = {
+      passage: "Passage",
+      items: Array.from({ length: 9 }, () => ({
+        stem: "Question",
+        options: ["A", "B", "C", "D"],
+      })),
+    };
+
+    expect(() => validateVstepExamBlueprint(blueprint, questions)).toThrow(
+      BadRequestError,
+    );
+  });
+
+  it("rejects writing when task minimum words are lower than standard", () => {
+    const { blueprint, questions } = makeValidDataset();
+    const writingTask2 = questions.find((question) => question.id === "w2");
+    if (!writingTask2) throw new Error("missing fixture question w2");
+
+    writingTask2.content = {
+      prompt: "Write",
+      taskType: "essay",
+      minWords: 200,
+    };
+
+    expect(() => validateVstepExamBlueprint(blueprint, questions)).toThrow(
+      BadRequestError,
+    );
+  });
+
+  it("rejects speaking when missing one required part", () => {
+    const { blueprint, questions } = makeValidDataset();
+    blueprint.speaking = { questionIds: ["s1", "s2"] };
+
+    const selectedQuestions = questions.filter((question) => question.id !== "s3");
+
+    expect(() => validateVstepExamBlueprint(blueprint, selectedQuestions)).toThrow(
+      BadRequestError,
+    );
+  });
+
+  it("rejects when question is assigned to wrong skill bucket", () => {
+    const { blueprint, questions } = makeValidDataset();
+    blueprint.listening = { questionIds: ["l1", "l2", "r1"] };
+
+    expect(() => validateVstepExamBlueprint(blueprint, questions)).toThrow(
+      BadRequestError,
+    );
+  });
+});

--- a/apps/backend/src/modules/exams/blueprint-validation.ts
+++ b/apps/backend/src/modules/exams/blueprint-validation.ts
@@ -1,0 +1,204 @@
+import { BadRequestError } from "@common/errors";
+import type { ExamBlueprint } from "@db/types/exam-blueprint";
+import type { QuestionContent } from "@db/types/question-content";
+
+const REQUIRED_SKILLS = ["listening", "reading", "writing", "speaking"] as const;
+
+type Skill = (typeof REQUIRED_SKILLS)[number];
+
+const LISTENING_EXPECTED_PART_ITEMS: Record<number, number> = {
+  1: 8,
+  2: 12,
+  3: 15,
+};
+
+const READING_EXPECTED_PART_ITEMS: Record<number, number> = {
+  1: 10,
+  2: 10,
+  3: 10,
+  4: 10,
+};
+
+type BlueprintQuestion = {
+  id: string;
+  skill: Skill;
+  part: number;
+  content: QuestionContent;
+};
+
+function getItemsCount(content: QuestionContent): number {
+  if (typeof content !== "object" || content === null) return 0;
+
+  if ("items" in content && Array.isArray(content.items)) {
+    return content.items.length;
+  }
+
+  return 0;
+}
+
+function getMinWords(content: QuestionContent): number | null {
+  if (typeof content !== "object" || content === null) return null;
+
+  if ("minWords" in content && typeof content.minWords === "number") {
+    return content.minWords;
+  }
+
+  return null;
+}
+
+function assertRequiredSkills(blueprint: ExamBlueprint): void {
+  for (const skill of REQUIRED_SKILLS) {
+    const questionIds = blueprint[skill]?.questionIds ?? [];
+    if (questionIds.length === 0) {
+      throw new BadRequestError(
+        `Blueprint must include at least one ${skill} question`,
+      );
+    }
+  }
+}
+
+function assertSkillOwnership(
+  blueprint: ExamBlueprint,
+  questionsById: Map<string, BlueprintQuestion>,
+): void {
+  for (const skill of REQUIRED_SKILLS) {
+    const questionIds = blueprint[skill]?.questionIds ?? [];
+
+    for (const questionId of questionIds) {
+      const question = questionsById.get(questionId);
+      if (!question) continue;
+
+      if (question.skill !== skill) {
+        throw new BadRequestError(
+          `Question ${questionId} belongs to ${question.skill}, cannot be used in ${skill} blueprint`,
+        );
+      }
+    }
+  }
+}
+
+function assertListening(questions: BlueprintQuestion[]): void {
+  const partTotals = new Map<number, number>();
+
+  for (const question of questions) {
+    const itemsCount = getItemsCount(question.content);
+    partTotals.set(question.part, (partTotals.get(question.part) ?? 0) + itemsCount);
+  }
+
+  for (const [part, expected] of Object.entries(LISTENING_EXPECTED_PART_ITEMS)) {
+    const partNumber = Number(part);
+    const actual = partTotals.get(partNumber) ?? 0;
+
+    if (actual !== expected) {
+      throw new BadRequestError(
+        `Listening part ${partNumber} must contain ${expected} items, found ${actual}`,
+      );
+    }
+  }
+
+  const total = [...partTotals.values()].reduce((sum, value) => sum + value, 0);
+  if (total !== 35) {
+    throw new BadRequestError(`Listening must contain exactly 35 items, found ${total}`);
+  }
+}
+
+function assertReading(questions: BlueprintQuestion[]): void {
+  const partTotals = new Map<number, number>();
+
+  for (const question of questions) {
+    const itemsCount = getItemsCount(question.content);
+    partTotals.set(question.part, (partTotals.get(question.part) ?? 0) + itemsCount);
+  }
+
+  for (const [part, expected] of Object.entries(READING_EXPECTED_PART_ITEMS)) {
+    const partNumber = Number(part);
+    const actual = partTotals.get(partNumber) ?? 0;
+
+    if (actual !== expected) {
+      throw new BadRequestError(
+        `Reading part ${partNumber} must contain ${expected} items, found ${actual}`,
+      );
+    }
+  }
+
+  const total = [...partTotals.values()].reduce((sum, value) => sum + value, 0);
+  if (total !== 40) {
+    throw new BadRequestError(`Reading must contain exactly 40 items, found ${total}`);
+  }
+}
+
+function assertWriting(questions: BlueprintQuestion[]): void {
+  const byPart = new Map<number, BlueprintQuestion[]>();
+  for (const question of questions) {
+    const partItems = byPart.get(question.part) ?? [];
+    partItems.push(question);
+    byPart.set(question.part, partItems);
+  }
+
+  const task1Questions = byPart.get(1) ?? [];
+  const task2Questions = byPart.get(2) ?? [];
+
+  if (task1Questions.length !== 1 || task2Questions.length !== 1 || byPart.size !== 2) {
+    throw new BadRequestError(
+      "Writing must contain exactly 2 tasks: part 1 (letter) and part 2 (essay)",
+    );
+  }
+
+  const task1 = task1Questions[0];
+  const task2 = task2Questions[0];
+  if (!task1 || !task2) {
+    throw new BadRequestError(
+      "Writing must contain exactly 2 tasks: part 1 (letter) and part 2 (essay)",
+    );
+  }
+
+  const task1MinWords = getMinWords(task1.content);
+  const task2MinWords = getMinWords(task2.content);
+
+  if (task1MinWords === null || task1MinWords < 120) {
+    throw new BadRequestError(
+      `Writing task 1 must require at least 120 words, found ${task1MinWords ?? 0}`,
+    );
+  }
+
+  if (task2MinWords === null || task2MinWords < 250) {
+    throw new BadRequestError(
+      `Writing task 2 must require at least 250 words, found ${task2MinWords ?? 0}`,
+    );
+  }
+}
+
+function assertSpeaking(questions: BlueprintQuestion[]): void {
+  const counts = new Map<number, number>();
+  for (const question of questions) {
+    counts.set(question.part, (counts.get(question.part) ?? 0) + 1);
+  }
+
+  for (const part of [1, 2, 3]) {
+    const count = counts.get(part) ?? 0;
+    if (count !== 1) {
+      throw new BadRequestError(
+        `Speaking part ${part} must contain exactly 1 question, found ${count}`,
+      );
+    }
+  }
+
+  if (counts.size !== 3) {
+    throw new BadRequestError("Speaking must contain exactly 3 parts");
+  }
+}
+
+export function validateVstepExamBlueprint(
+  blueprint: ExamBlueprint,
+  questions: BlueprintQuestion[],
+): void {
+  assertRequiredSkills(blueprint);
+
+  const questionsById = new Map(questions.map((question) => [question.id, question]));
+  assertSkillOwnership(blueprint, questionsById);
+
+  assertListening(questions.filter((question) => question.skill === "listening"));
+  assertReading(questions.filter((question) => question.skill === "reading"));
+  assertWriting(questions.filter((question) => question.skill === "writing"));
+  assertSpeaking(questions.filter((question) => question.skill === "speaking"));
+}

--- a/apps/backend/src/modules/exams/service.ts
+++ b/apps/backend/src/modules/exams/service.ts
@@ -10,6 +10,7 @@ import type { ExamSession } from "@db/schema/exams";
 import { and, desc, eq, inArray } from "drizzle-orm";
 import type { ExamCreateBody, ExamListQuery, ExamUpdateBody } from "./schema";
 import { EXAM_COLUMNS } from "./schema";
+import { validateVstepExamBlueprint } from "./blueprint-validation";
 
 export type ExamSessionStatus = ExamSession["status"];
 
@@ -32,18 +33,25 @@ async function validateBlueprint(
     throw new BadRequestError("Exam must contain at least one question");
 
   const found = await tx
-    .select({ id: table.questions.id })
+    .select({
+      id: table.questions.id,
+      skill: table.questions.skill,
+      part: table.questions.part,
+      content: table.questions.content,
+    })
     .from(table.questions)
     .where(
       and(inArray(table.questions.id, ids), eq(table.questions.isActive, true)),
     );
 
-  if (found.length === ids.length) return;
-
   const have = new Set(found.map((q) => q.id));
-  throw new BadRequestError(
-    `Blueprint references non-existent or inactive questions: [${ids.filter((id) => !have.has(id)).join(", ")}]`,
-  );
+  if (found.length !== ids.length) {
+    throw new BadRequestError(
+      `Blueprint references non-existent or inactive questions: [${ids.filter((id) => !have.has(id)).join(", ")}]`,
+    );
+  }
+
+  validateVstepExamBlueprint(blueprint, found);
 }
 
 export async function find(id: string, actor: Actor) {


### PR DESCRIPTION
### Motivation

- Enforce VSTEP-specific blueprint rules (counts per part and task minima) when creating exams to prevent invalid exam configurations.

### Description

- Add `apps/backend/src/modules/exams/blueprint-validation.ts` which implements `validateVstepExamBlueprint` with per-skill checks for listening, reading, writing, and speaking including expected item counts and minimum word requirements.
- Add unit tests in `apps/backend/src/modules/exams/blueprint-validation.test.ts` covering valid and multiple invalid blueprint scenarios.
- Integrate validation into the exam creation flow by importing and calling `validateVstepExamBlueprint` from `apps/backend/src/modules/exams/service.ts` and update the DB select to fetch `skill`, `part`, and `content` for referenced questions.
- Improve error handling to explicitly fail when referenced questions are missing or inactive before running the blueprint validator.

### Testing

- Ran the new unit tests in `apps/backend/src/modules/exams/blueprint-validation.test.ts` using the test harness (`bun test`) and they passed.
- Ran the backend test suite (`bun test`) to ensure integration into the service did not break other tests and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afc44bd9b883239e5f79f9eb385552)